### PR TITLE
Convert shanmugha13/shanmugha13-Docker-container-CI to GitHub Actions

### DIFF
--- a/.github/workflows/shanmugha13-docker-container-ci.yml
+++ b/.github/workflows/shanmugha13-docker-container-ci.yml
@@ -1,0 +1,20 @@
+name: shanmugha13/shanmugha13-Docker-container-CI
+on:
+  push:
+    branches:
+    - main
+env:
+  system_debug: 'false'
+jobs:
+  Job_1:
+    name: Agent job 1
+    runs-on:
+      - self-hosted
+      - ubuntu-22.04
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3.3.0
+    - name: Build an image
+      run: docker build . --file "Dockerfile" --tag shanmugha13/docker-pipeline:${{ github.run_id }} -t shanmugha13/docker-pipeline:latest
+    - name: Push an image
+      run: docker push shanmugha13/docker-pipeline:${{ github.run_id }}


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/shanmugha13/shanmugha13/_build?definitionId=12) :tada:

## Manual steps

Perform the follow steps to complete the migration:

### shanmugha13/shanmugha13-Docker-container-CI
- [x] Ensure a runner with the following labels exists: ubuntu-22.04
- [ ] Ensure: We have replaced '**/Dockerfile'' with 'Dockerfile'. Ensure this works for you and adjust build context and docker path if needed